### PR TITLE
Remove fortnitepy old "partners"

### DIFF
--- a/docs/help.rst
+++ b/docs/help.rst
@@ -6,7 +6,7 @@ Need more help?
 Support Discord
 ---------------
 
-Feel free to join `this discord <https://discord.gg/rnk869s>`_. Asking question about the library there will greatly speed up the average response time as there are multiple experienced members (hopefully) available that can offer you help. Keep in mind that this is a discord server for general epicgames app development. Use ``#fortnitepy-help`` for rebootpy related questions.
+Feel free to join `this discord <https://discord.gg/rnk869s>`_. Asking question about the library there will greatly speed up the average response time as there are multiple experienced members (hopefully) available that can offer you help. Keep in mind that this is a discord server for general epicgames app development. Use ``#fortnitepy`` for rebootpy related questions.
 
 If you need to get in contact with me directly, you can join the discord above and then ping me (`mistxoli``).
 

--- a/docs/usedby.rst
+++ b/docs/usedby.rst
@@ -1,43 +1,6 @@
 .. currentmodule:: rebootpy
 
-Who uses fortnitepy?
+Who uses rebootpy?
 ====================
 
-Yunite
-------
-
-.. image:: https://yunite.xyz/img/android-chrome-384x384.png
-   :target: https://yunite.xyz
-   :height: 100
-
-Yunite is a multipurpose discord bot that offers features like safe custom game registration, self organized tournaments with accurate placings and more.
-
-
-Rematch.gg
-----------
-
-.. image:: https://rematch.gg/assets/img/logo/rematch-full-new.png
-   :target: https://rematch.gg
-   :height: 100
-
-Rematch.gg is a platform that hosts fortnite scrims for cash prizes as well as offer a place for people to connect and play tournaments, zone wars, box fights and more.
-
-
-PartyBot
---------
-
-.. image:: https://partybot.net/cdn/skull.png
-   :target: https://github.com/xmistt/fortnitepy-bot
-   :height: 100
-
-PartyBot is a self hosted so called lobby bot that you can mess around with in a party. You can use it to showcase rare outfits and other cosmetics.
-
-
-EasyFortniteStats
------------------
-
-.. image:: https://gblobscdn.gitbook.com/spaces%2F-LjpXsmo7aeUKmSF7KVz%2Favatar-1612982571858.png?alt=media
-   :target: https://www.easyfnstats.com
-   :height: 100
-
-EasyFortniteStats is a discord bot built around fortnite stats and news. It features graphical stats, item shop, ingame radio and more.
+None for the moment...

--- a/rebootpy/party.py
+++ b/rebootpy/party.py
@@ -3511,10 +3511,6 @@ class ClientPartyMember(PartyMemberBase, Patchable):
             return await self.patch(updated=prop)
 
 
-import asyncio
-from collections import OrderedDict
-from typing import List, Optional, Tuple
-
 class PartyBase:
     def __init__(self, client: 'Client', data: dict) -> None:
         self._client = client

--- a/rebootpy/party.py
+++ b/rebootpy/party.py
@@ -3523,6 +3523,23 @@ class PartyBase:
         self._update_config(data.get('config'))
         self.meta = PartyMeta(self, data['meta'])
 
+        members = data.get('members')
+        if members:
+            asyncio.create_task(
+                self._update_members(
+                    members,
+                    remove_missing=False,
+                    fetch_user_data=False
+                )
+            )
+
+    async def _update_members(
+        self,
+        members_data: list,
+        remove_missing: bool = True,
+        fetch_user_data: bool = True
+    ) -> None:
+
     def __str__(self) -> str:
         return self.id
 

--- a/rebootpy/party.py
+++ b/rebootpy/party.py
@@ -3539,6 +3539,17 @@ class PartyBase:
         remove_missing: bool = True,
         fetch_user_data: bool = True
     ) -> None:
+        existing_ids = set(self._members.keys())
+        incoming_ids = set()
+
+        for raw in members_data:
+            member = await self._create_member(raw, fetch_user_data)
+            incoming_ids.add(member.id)
+            self._members[member.id] = member
+
+        if remove_missing:
+            for missing in existing_ids - incoming_ids:
+                del self._members[missing]
 
     def __str__(self) -> str:
         return self.id


### PR DESCRIPTION
Remove services that use fortnitepy. Services that use rebootpy should be displayed here instead, correct?